### PR TITLE
Fix ghcr.io push permission_denied by using GITHUB_TOKEN

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,6 +28,8 @@ jobs:
     name: Build
     needs: label-detector
     runs-on: "${{ needs.label-detector.outputs.runs-on }}"
+    permissions:
+      packages: write
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
@@ -46,12 +48,11 @@ jobs:
         uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
       - name: Log in to the GitHub Container registry
-        env:
-          REGISTRY: ghcr.io/kubedb
-          DOCKER_TOKEN: ${{ secrets.LGTM_GITHUB_TOKEN }}
-          USERNAME: 1gtm
-        run: |
-          docker login ghcr.io --username ${USERNAME} --password ${DOCKER_TOKEN}
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run checks
         run: |


### PR DESCRIPTION
## Summary
- The Release job's push to `ghcr.io/kubedb/pgbouncer` failed with `denied: permission_denied: write_package` ([run](https://github.com/kubedb/pgbouncer-docker/actions/runs/29993382897/job/89167237302)), even though the `1gtm` bot account used to authenticate has write access to this repo.
- Login succeeded (basic auth via PAT works), but the push was denied — consistent with `LGTM_GITHUB_TOKEN` being a fine-grained PAT, which doesn't support the GitHub Packages/Container Registry write API.
- Switches the login step to `docker/login-action` using `github.actor` + `secrets.GITHUB_TOKEN`, and grants the job `packages: write`, matching the approach already used on other branches.

## Test plan
- [ ] Push a test tag (or re-run via `workflow_dispatch`) and confirm the `docker push` step succeeds